### PR TITLE
Fix link for stacked bar chart

### DIFF
--- a/packages/documentation/content/markdown/documentation/03_examples.md
+++ b/packages/documentation/content/markdown/documentation/03_examples.md
@@ -9,7 +9,7 @@ order: 3
 ### Bar Charts
 
 - [Bar Chart](/documentation/examples/bar_chart)
-- [Stacked Bar Chart](/documentation/examples/bar_chart)
+- [Stacked Bar Chart](/documentation/examples/stacked_bar_chart)
 - [Grouped Bar Chart](/documentation/examples/grouped_bar_chart)
 
 ### Line & Area Charts


### PR DESCRIPTION
The purpose of this pull request is to fix the link for the "Stacked Bar Chart" in the examples documentation.

![image](https://user-images.githubusercontent.com/606001/55519737-018a0500-5647-11e9-8f8d-c13df0ec63ad.png)
