### PR TITLE
Clean up generated API documentation

### DIFF
--- a/packages/client/builder/src/api/AxisBuilder.ts
+++ b/packages/client/builder/src/api/AxisBuilder.ts
@@ -12,6 +12,10 @@ import {
 import { Subject } from 'rxjs'
 import { AxisSpec } from '../spec/AxisSpec'
 
+/**
+ * A builder class for defining Axes
+ * @category Builder
+ */
 export class AxisBuilder {
 	public readonly onChange = new Subject<any>()
 	public readonly spec: AxisSpec

--- a/packages/client/builder/src/api/ChartOptionsManager.ts
+++ b/packages/client/builder/src/api/ChartOptionsManager.ts
@@ -10,6 +10,10 @@ import {
 	ItemSpace,
 } from '@chart-parts/interfaces'
 
+/**
+ * A class for managing chart options
+ * @category Builder
+ */
 export class ChartOptionsManager {
 	public constructor(private options: ChartOptions = {}) {}
 

--- a/packages/client/builder/src/api/MarkBuilder.ts
+++ b/packages/client/builder/src/api/MarkBuilder.ts
@@ -31,6 +31,10 @@ import { SceneNodeBuilder } from './SceneNodeBuilder'
 import { Subject, Subscription } from 'rxjs'
 import { MarkSpec } from '../spec/MarkSpec'
 
+/**
+ * A builder component for mark specifications
+ * @category Builder
+ */
 export class MarkBuilder {
 	public readonly onChange = new Subject()
 	public readonly spec: MarkSpec

--- a/packages/client/builder/src/api/SceneNodeBuilder.ts
+++ b/packages/client/builder/src/api/SceneNodeBuilder.ts
@@ -13,6 +13,10 @@ interface SubscribableHandle<T> {
 	subscription: Subscription
 }
 
+/**
+ * The build component for scene nodes
+ * @category Builder
+ */
 export class SceneNodeBuilder {
 	public readonly onChange = new Subject<any>()
 	public readonly spec = new SceneNodeSpec()

--- a/packages/client/builder/src/api/factories.ts
+++ b/packages/client/builder/src/api/factories.ts
@@ -15,6 +15,7 @@ import { ChartOptionsManager } from './ChartOptionsManager'
 
 /**
  * A factory function for creating a new scene
+ * @category Builder
  */
 export function scene(
 	cb: (child: SceneNodeBuilder) => SceneNodeBuilder,
@@ -38,52 +39,116 @@ export function scene(
 /**
  * A factory function for creating a new mark
  * @param type The mark type to create
+ * @category Builder
  */
 export function mark(type: MarkType) {
 	return new MarkBuilder(type)
 }
 
-//
-// Utility functions for creating typed marks
-//
-
 /**
- * Initiates construction of a new _arc_ typed mark
+ * Creates a new _arc_ type mark
  * @param name
+ * @category Builder
  */
 export function arc(name?: string) {
 	return markWithName(MarkType.Arc, name)
 }
+
+/**
+ * Creates a new _area_ type mark
+ * @category Builder
+ * @param name
+ */
 export function area(name?: string) {
 	return markWithName(MarkType.Area, name)
 }
+
+/**
+ * Creates a new _group_ type mark
+ * @category Builder
+ * @param name
+ */
 export function group(name?: string) {
 	return markWithName(MarkType.Group, name)
 }
+
+/**
+ * Creates a new _image_ type mark
+ * @category Builder
+ * @param name
+ */
 export function image(name?: string) {
 	return markWithName(MarkType.Image, name)
 }
+
+/**
+ * Creates a new _line_ type mark
+ * @category Builder
+ * @param name
+ */
 export function line(name?: string) {
 	return markWithName(MarkType.Line, name)
 }
+
+/**
+ * Creates a new _path_ type mark
+ * @category Builder
+ * @param name
+ */
 export function path(name?: string) {
 	return markWithName(MarkType.Path, name)
 }
+
+/**
+ * Creates a new _rect_ type mark
+ * @category Builder
+ * @param name
+ */
 export function rect(name?: string) {
 	return markWithName(MarkType.Rect, name)
 }
+
+/**
+ * Creates a new _rule_ type mark
+ * @category Builder
+ * @param name
+ */
 export function rule(name?: string) {
 	return markWithName(MarkType.Rule, name)
 }
+
+/**
+ * Creates a new _shape_ type mark
+ * @category Builder
+ * @param name
+ */
 export function shape(name?: string) {
 	return markWithName(MarkType.Shape, name)
 }
+
+/**
+ * Creates a new _symbol_ type mark
+ * @category Builder
+ * @param name
+ */
 export function symbol(name?: string) {
 	return markWithName(MarkType.Symbol, name)
 }
+
+/**
+ * Creates a new _text_ type mark
+ * @category Builder
+ * @param name
+ */
 export function text(name?: string) {
 	return markWithName(MarkType.Text, name)
 }
+
+/**
+ * Creates a new _trail_ type mark
+ * @category Builder
+ * @param name
+ */
 export function trail(name?: string) {
 	return markWithName(MarkType.Trail, name)
 }
@@ -97,6 +162,7 @@ function markWithName(markType: MarkType, name?: string) {
  * Creates a new Axis builder
  * @param scale The name of the scale to align the axis with
  * @param orientation The positioning of the axis in the view-space
+ * @category Builder
  */
 export function axis(scale: string, orientation: AxisOrientation): AxisBuilder {
 	return new AxisBuilder(scale, orientation)

--- a/packages/client/builder/src/spec/AxisSpec.ts
+++ b/packages/client/builder/src/spec/AxisSpec.ts
@@ -25,6 +25,10 @@ import {
 	DEFAULT_AXIS_BAND_POSITION,
 } from './defaults'
 
+/**
+ * Axis Specification Object
+ * @category Specification
+ */
 export class AxisSpec implements Axis {
 	private _thickness: number = DEFAULT_AXIS_THICKNESS
 

--- a/packages/client/builder/src/spec/MarkSpec.ts
+++ b/packages/client/builder/src/spec/MarkSpec.ts
@@ -14,6 +14,10 @@ import {
 } from '@chart-parts/interfaces'
 import { SceneNodeSpec } from './SceneNodeSpec'
 
+/**
+ * Mark Specification Object
+ * @category Specification
+ */
 export class MarkSpec implements Mark {
 	private _table: string | undefined
 	private _channels: Channels = {}

--- a/packages/client/builder/src/spec/SceneNodeSpec.ts
+++ b/packages/client/builder/src/spec/SceneNodeSpec.ts
@@ -6,6 +6,10 @@ import { SceneNode, ScaleCreator } from '@chart-parts/interfaces'
 import { MarkSpec } from './MarkSpec'
 import { AxisSpec } from './AxisSpec'
 
+/**
+ * Scene Specification Object
+ * @category Specification
+ */
 export class SceneNodeSpec implements SceneNode {
 	private _scales: ScaleCreator[] = []
 	private _marks: MarkSpec[] = []

--- a/packages/client/builder/src/spec/defaults.ts
+++ b/packages/client/builder/src/spec/defaults.ts
@@ -2,17 +2,87 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
+
+/**
+ * Default Axis coloring
+ * @category Specification
+ */
 export const DEFAULT_AXIS_COLOR = '#777'
+
+/**
+ * Default text color
+ * @category Specification
+ */
 export const DEFAULT_AXIS_TEXT_COLOR = '#000'
+
+/**
+ * Default axis line thickness
+ * @category Specification
+ */
 export const DEFAULT_AXIS_STROKE = 1
+
+/**
+ * Default axis tick size
+ * @category Specification
+ */
 export const DEFAULT_AXIS_TICK_SIZE = 5
+
+/**
+ * Default axis font size
+ * @category Specification
+ */
 export const DEFAULT_AXIS_FONT_SIZE = 10
+
+/**
+ * Default axis font
+ * @category Specification
+ */
 export const DEFAULT_AXIS_FONT = 'sans-serif'
+
+/**
+ * Default Axis Label Padding
+ * @category Specification
+ */
 export const DEFAULT_AXIS_LABEL_PADDING = 1
+
+/**
+ * Default Axis Band Position
+ * @category Specification
+ */
 export const DEFAULT_AXIS_BAND_POSITION = 0.5
+
+/**
+ * Default Axis Thickness
+ * @category Specification
+ */
 export const DEFAULT_AXIS_THICKNESS = 25
+
+/**
+ * Default Axis Tick Offset
+ * @category Specification
+ */
 export const DEFAULT_AXIS_TICK_OFFSET_VALUE = 0
+
+/**
+ * Default Axis Domain Flag
+ * @category Specification
+ */
 export const DEFAULT_AXIS_DOMAIN_VALUE = true
+
+/**
+ * Default Axis Ticks Flag
+ * @category Specification
+ */
 export const DEFAULT_AXIS_TICKS_VALUE = true
+
+/**
+ * Default Axis Round Flag
+ * @category Specification
+ */
 export const DEFAULT_AXIS_TICK_ROUND_VALUE = false
+
+/**
+ * Default Axis Labels Flag
+ * @category Specification
+ */
 export const DEFAULT_AXIS_LABELS_VALUE = true

--- a/packages/client/builder/src/xform/axes/buildAxis.ts
+++ b/packages/client/builder/src/xform/axes/buildAxis.ts
@@ -13,10 +13,13 @@ import { buildMark } from '@chart-parts/scenegraph'
 import { SceneFrame } from '../context/SceneFrame'
 import { components } from './components'
 import { SGMarkAny } from '../processNode'
-import { AxisSpace } from '../interfaces'
+import { AxisSpace } from './interfaces'
 import { getContext } from './getContext'
 import { AxisContext } from './interfaces'
 
+/**
+ * @ignore
+ */
 export function buildAxis(
 	axis: Axis,
 	frame: SceneFrame,

--- a/packages/client/builder/src/xform/axes/components/domain/crossValue.ts
+++ b/packages/client/builder/src/xform/axes/components/domain/crossValue.ts
@@ -5,6 +5,9 @@
 
 import { Axis, AxisOrientation } from '@chart-parts/interfaces'
 
+/**
+ * @ignore
+ */
 export function crossValue(axis: Axis, thickness: number): number {
 	const domainWidth = axis.domainWidth as number
 	const { orient } = axis

--- a/packages/client/builder/src/xform/axes/components/domain/index.ts
+++ b/packages/client/builder/src/xform/axes/components/domain/index.ts
@@ -8,6 +8,9 @@ import { buildMark } from '@chart-parts/scenegraph'
 import { AxisContext, AxisComponent } from '../../interfaces'
 import { crossValue } from './crossValue'
 
+/**
+ * @ignore
+ */
 export class Domain implements AxisComponent {
 	public createContext(context: Partial<AxisContext>) {
 		const range = context.range as [number, number]

--- a/packages/client/builder/src/xform/axes/components/index.ts
+++ b/packages/client/builder/src/xform/axes/components/index.ts
@@ -10,6 +10,7 @@ import { TickLabels } from './tickLabels'
 
 /**
  * The axis component class instances
+ * @ignore
  */
 export const components: AxisComponent[] = [
 	new Domain(),

--- a/packages/client/builder/src/xform/axes/components/tickLabels/index.ts
+++ b/packages/client/builder/src/xform/axes/components/tickLabels/index.ts
@@ -17,6 +17,9 @@ import {
 	AxisComponent,
 } from '../../interfaces'
 
+/**
+ * @ignore
+ */
 export class TickLabels implements AxisComponent {
 	public createContext(context: Partial<AxisContext>) {
 		return context

--- a/packages/client/builder/src/xform/axes/components/tickLines/getLabelFormatter.ts
+++ b/packages/client/builder/src/xform/axes/components/tickLines/getLabelFormatter.ts
@@ -12,6 +12,9 @@ function isTimeScale(scale: Scale<any, any>) {
 	return scale.__scaletype__ === 'utc' || scale.__scaletype__ === 'time'
 }
 
+/**
+ * @ignore
+ */
 export function getLabelFormatter(
 	context: AxisContext,
 ): (input: any) => string {

--- a/packages/client/builder/src/xform/axes/components/tickLines/getTickValues.ts
+++ b/packages/client/builder/src/xform/axes/components/tickLines/getTickValues.ts
@@ -8,6 +8,7 @@ import { AxisContext, PositionedTickValue } from '../../interfaces'
 
 /**
  * Gets logical tick values and their associated labels
+ * @ignore
  * @param context The axis context
  */
 export function getTickValues(context: AxisContext): PositionedTickValue[] {

--- a/packages/client/builder/src/xform/axes/components/tickLines/index.ts
+++ b/packages/client/builder/src/xform/axes/components/tickLines/index.ts
@@ -13,6 +13,9 @@ import {
 import { getTickValues } from './getTickValues'
 import { getLabelFormatter } from './getLabelFormatter'
 
+/**
+ * @ignore
+ */
 export class TickLines implements AxisComponent {
 	public createContext(context: AxisContext) {
 		const tickCrossStart = getTickCrossStart(context as AxisContext)

--- a/packages/client/builder/src/xform/axes/getContext.ts
+++ b/packages/client/builder/src/xform/axes/getContext.ts
@@ -5,9 +5,12 @@
 
 import { Axis, AxisOrientation, ViewSize } from '@chart-parts/interfaces'
 import { SceneFrame } from '../context/SceneFrame'
-import { AxisSpace } from '../interfaces'
+import { AxisSpace } from './interfaces'
 import { AxisContext } from './interfaces'
 
+/**
+ * @ignore
+ */
 export function getContext(
 	axis: Axis,
 	frame: SceneFrame,

--- a/packages/client/builder/src/xform/axes/index.ts
+++ b/packages/client/builder/src/xform/axes/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@chart-parts/interfaces'
 import { SceneFrame } from '../context/SceneFrame'
 import { buildAxis } from './buildAxis'
-import { AxisSpace } from '../interfaces'
+import { AxisSpace } from './interfaces'
 import { SGMarkAny } from '../processNode'
 import { DEFAULT_AXIS_THICKNESS } from '../../spec/defaults'
 
@@ -19,6 +19,7 @@ import { DEFAULT_AXIS_THICKNESS } from '../../spec/defaults'
  * Builds axes into a screen frame
  * @param node The current scene node
  * @param frame Thec curren scene frame
+ * @ignore
  */
 export function buildAxes(
 	node: SceneNode,

--- a/packages/client/builder/src/xform/axes/interfaces.ts
+++ b/packages/client/builder/src/xform/axes/interfaces.ts
@@ -6,6 +6,13 @@
 import { SGMark, Axis, Scale, TickValue } from '@chart-parts/interfaces'
 import { SceneFrame } from '../context/SceneFrame'
 
+export interface AxisSpace {
+	top: number
+	right: number
+	bottom: number
+	left: number
+}
+
 /**
  * A context object for generating axis components
  */

--- a/packages/client/builder/src/xform/context/SceneFrame.ts
+++ b/packages/client/builder/src/xform/context/SceneFrame.ts
@@ -18,6 +18,7 @@ import {
 /**
  * The scene frame is analagous to a stack-frame - it contains contextual
  * information for a section of a scene, including dimensions, scales, data, and event handlers
+ * @ignore
  */
 export class SceneFrame {
 	public constructor(

--- a/packages/client/builder/src/xform/createScenegraph.ts
+++ b/packages/client/builder/src/xform/createScenegraph.ts
@@ -5,19 +5,23 @@
 import { ChartOptions, SceneNode, DataFrame } from '@chart-parts/interfaces'
 import { ChartOptionsManager } from '../api/ChartOptionsManager'
 import { SceneFrame } from './context/SceneFrame'
-import { GeneratedScene } from './interfaces'
+import { GeneratedScenegraph } from './interfaces'
 import { processNode } from './processNode'
 
 /**
  * Builds a new scenegraph instance by binding data to a scene specification.
  *
- * @param data The data to bind with
+ * @category Transformation
+ * @param root The scene specifiaction
+ * @param data The data tables
+ * @param options The charting options
+ * @returns A generated scenegraph
  */
 export function createScenegraph(
 	root: SceneNode,
 	data: DataFrame,
 	options: ChartOptions,
-): GeneratedScene {
+): GeneratedScenegraph {
 	const optionsManager = new ChartOptionsManager(options)
 	const width = optionsManager.chartSpace.shape.width as number
 	const height = optionsManager.chartSpace.shape.height as number

--- a/packages/client/builder/src/xform/interfaces.ts
+++ b/packages/client/builder/src/xform/interfaces.ts
@@ -7,8 +7,10 @@ import { SGMark, SGItem, Channels } from '@chart-parts/interfaces'
 
 /**
  * Interface for the result of scene-generation
+ * @category Transformation
  */
-export interface GeneratedScene {
+
+export interface GeneratedScenegraph {
 	/**
 	 * The root mark of the resultant scene
 	 */
@@ -18,11 +20,4 @@ export interface GeneratedScene {
 	 * The event channels of this scene, a key of channel name to event handlers
 	 */
 	channelHandlers: Channels
-}
-
-export interface AxisSpace {
-	top: number
-	right: number
-	bottom: number
-	left: number
 }

--- a/packages/client/builder/src/xform/marks/createBoundItem.ts
+++ b/packages/client/builder/src/xform/marks/createBoundItem.ts
@@ -23,6 +23,7 @@ import { processNode } from '../processNode'
 /**
  * Creates a scenegraph item bound to a data row
  *
+ * @ignore
  * @param frame The current scene frame
  * @param row The data row
  * @param index The data row index

--- a/packages/client/builder/src/xform/marks/processMark.ts
+++ b/packages/client/builder/src/xform/marks/processMark.ts
@@ -8,12 +8,18 @@ import { createMark } from '@chart-parts/scenegraph'
 import { SceneFrame } from '../context/SceneFrame'
 import { createBoundItem } from './createBoundItem'
 
+/**
+ * @ignore
+ */
 export interface FacetedData {
 	name: string
 	keyRowName?: string
 	facets: DataFacet[]
 }
 
+/**
+ * @ignore
+ */
 export interface DataFacet {
 	parent?: any
 	key: string
@@ -22,6 +28,9 @@ export interface DataFacet {
 
 type BoundData = any[] | FacetedData
 
+/**
+ * @ignore
+ */
 export function processMark(mark: Mark, frame: SceneFrame): SGMark<SGItem> {
 	const markFrame = frame.pushMark(mark)
 	const boundData = getBoundData(mark, markFrame)

--- a/packages/client/builder/src/xform/processNode.ts
+++ b/packages/client/builder/src/xform/processNode.ts
@@ -19,6 +19,7 @@ export type SGMarkAny = SGMark<SGItem>
 
 /**
  * Processes a scene specification node into the SceneGraph model
+ * @ignore
  * @param node The scene node to process
  * @param scaleFrame The scales available for the given scene node
  */

--- a/packages/client/react/README.md
+++ b/packages/client/react/README.md
@@ -1,3 +1,3 @@
-## Purpose
+# Overview
 
-This library contains the Renderless React components that can be used to describe charting specifications in React and React-Native contexts.
+This library contains React components for describing charting elements within **chart-parts**

--- a/packages/client/react/src/Axis.tsx
+++ b/packages/client/react/src/Axis.tsx
@@ -10,6 +10,7 @@ import { SceneBuilderContext } from './Context'
 
 /**
  * Axis Component Props
+ * @category Utility
  */
 export interface AxisProps {
 	/**
@@ -58,6 +59,12 @@ export interface AxisProps {
 	// #endregion
 }
 
+/**
+ * The Axis component is used to define axes on a chart. Axes are always
+ * bound to a scale using the *scale* prop and are anchored to an edge of the
+ * available view space using the *orient* prop.
+ * @category Utility
+ */
 export const Axis: React.FC<AxisProps> = memo(
 	({ children, scale, orient, ...props }) => {
 		const api = useContext(SceneBuilderContext)
@@ -77,6 +84,11 @@ export const Axis: React.FC<AxisProps> = memo(
 	},
 )
 
+/**
+ * Synchronize React props with the Axis Builder object.
+ * @param axis The Axis builder instance
+ * @param props The Axis react props
+ */
 function useAxisProps(axis: AxisBuilder, props: AxisProps) {
 	useEffect(() => {
 		axis.thickness(props.thickness)

--- a/packages/client/react/src/Chart.tsx
+++ b/packages/client/react/src/Chart.tsx
@@ -18,6 +18,10 @@ import { observeOn } from 'rxjs/operators'
 import { animationFrameScheduler } from 'rxjs'
 import { SceneBuilderContext, ChartRendererContext } from './Context'
 
+/**
+ * A specification for the padding to apply to the chart
+ * @category Chart
+ */
 export interface ChartPadding {
 	top?: number
 	bottom?: number
@@ -25,6 +29,10 @@ export interface ChartPadding {
 	right?: number
 }
 
+/**
+ * Chart component props
+ * @category Chart
+ */
 export interface ChartProps {
 	width: number
 	height: number
@@ -35,13 +43,10 @@ export interface ChartProps {
 	description?: string
 }
 
-export interface ChartState {
-	/**
-	 * The result of the rendering process
-	 */
-	rendered: React.ReactNode
-}
-
+/**
+ * The Chart Component, the root of all charts
+ * @category Chart
+ */
 export const Chart: React.FC<ChartProps> = memo(
 	({ data, children, width, height, padding, title, description }) => {
 		const chartOptions = useChartOptions(

--- a/packages/client/react/src/Context.ts
+++ b/packages/client/react/src/Context.ts
@@ -7,10 +7,20 @@ import React from 'react'
 import { SceneNodeBuilder } from '@chart-parts/builder'
 import { Renderer, VSvgNode } from '@chart-parts/interfaces'
 
+/**
+ * A context value for the current scene-node. This is mainly used
+ * internally by the React components to interact with the builder API.
+ * @ignore
+ */
 export const SceneBuilderContext = React.createContext<
 	SceneNodeBuilder | undefined
 >(undefined)
 
+/**
+ * A context value for the charting renderer to use. This should
+ * appear above any charts.
+ * @ignore.
+ */
 export const ChartRendererContext = React.createContext<
 	Renderer<VSvgNode, any> | undefined
 >(undefined)

--- a/packages/client/react/src/index.ts
+++ b/packages/client/react/src/index.ts
@@ -5,10 +5,15 @@
 import { ChartRendererContext } from './Context'
 export * from './Chart'
 export * from './Axis'
-export * from './interfaces'
+export * from './types'
 export * from './scales'
 export * from './marks'
 
+/**
+ * A function that provides the charting renderer implementation
+ * to use across the application.
+ * @category Chart
+ */
 export const ChartingProvider = ChartRendererContext.Provider
 export { Dimension } from '@chart-parts/interfaces'
 export { CategoricalColorScheme } from '@chart-parts/scales'

--- a/packages/client/react/src/marks/Arc.ts
+++ b/packages/client/react/src/marks/Arc.ts
@@ -8,11 +8,15 @@ import {
 	MarkEncoding,
 	MarkEncodingKey,
 } from '@chart-parts/interfaces'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { MarkBuilder } from '@chart-parts/builder'
 import { useEffect } from 'react'
 
+/**
+ * Arc Mark Props
+ * @category Mark
+ */
 export interface ArcProps extends CommonMarkProps {
 	startAngle?: MarkEncoding<number>
 	endAngle?: MarkEncoding<number>
@@ -22,6 +26,10 @@ export interface ArcProps extends CommonMarkProps {
 	cornerRadius?: MarkEncoding<number>
 }
 
+/**
+ * Arc Mark Component
+ * @category Mark
+ */
 export const Arc = createMarkComponent<ArcProps>(
 	MarkType.Arc,
 	(mark: MarkBuilder, props) => {

--- a/packages/client/react/src/marks/Area.ts
+++ b/packages/client/react/src/marks/Area.ts
@@ -4,12 +4,16 @@
  */
 
 import { MarkType, Orientation, Interpolation } from '@chart-parts/interfaces'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { useEffect } from 'react'
 import { MarkBuilder } from '@chart-parts/builder'
 import { MarkEncodingKey, MarkEncoding } from '@chart-parts/interfaces'
 
+/**
+ * Area Mark Component Props
+ * @category Mark
+ */
 export interface AreaProps extends CommonMarkProps {
 	orient?: MarkEncoding<Orientation>
 	interpolate?: MarkEncoding<Interpolation>
@@ -17,6 +21,10 @@ export interface AreaProps extends CommonMarkProps {
 	defined?: MarkEncoding<boolean>
 }
 
+/**
+ * Area Mark Component
+ * @category Mark
+ */
 export const Area = createMarkComponent<AreaProps>(
 	MarkType.Area,
 	(mark: MarkBuilder, props) => {

--- a/packages/client/react/src/marks/BaseMark.tsx
+++ b/packages/client/react/src/marks/BaseMark.tsx
@@ -10,9 +10,15 @@ import {
 	MarkBuilder,
 	SceneNodeBuilder,
 } from '@chart-parts/builder'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { MarkEncodingKey } from '@chart-parts/interfaces'
 
+/**
+ * A factory function for creating mark components
+ * @param markType The mark type to create
+ * @param customHook An optional custom hook to use when themark is created
+ * @ignore
+ */
 export function createMarkComponent<T extends CommonMarkProps>(
 	markType: MarkType,
 	customHook: (mark: MarkBuilder, props: T) => void = () => null,

--- a/packages/client/react/src/marks/Group.ts
+++ b/packages/client/react/src/marks/Group.ts
@@ -10,15 +10,24 @@ import {
 	MarkEncodingKey,
 } from '@chart-parts/interfaces'
 import { MarkBuilder } from '@chart-parts/builder'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { useEffect } from 'react'
 
+/**
+ * Group Mark Component Props
+ * @category Mark
+ */
 export interface GroupProps extends CommonMarkProps {
 	clip?: MarkEncoding<boolean>
 	cornerRadius?: MarkEncoding<number>
 	facet?: Facet
 }
+
+/**
+ * Group Mark Component
+ * @category Mark
+ */
 export const Group = createMarkComponent<GroupProps>(
 	MarkType.Group,
 	(mark: MarkBuilder, props) => {

--- a/packages/client/react/src/marks/Line.tsx
+++ b/packages/client/react/src/marks/Line.tsx
@@ -9,17 +9,25 @@ import {
 	MarkEncoding,
 	MarkEncodingKey,
 } from '@chart-parts/interfaces'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { useEffect } from 'react'
 import { MarkBuilder } from '@chart-parts/builder'
 
+/**
+ * Line Mark Component Props
+ * @category Mark
+ */
 export interface LineProps extends CommonMarkProps {
 	interpolate?: MarkEncoding<Interpolation>
 	tension?: MarkEncoding<number>
 	defined?: MarkEncoding<boolean>
 }
 
+/**
+ * Line Mark Component
+ * @category Mark
+ */
 export const Line = createMarkComponent<LineProps>(
 	MarkType.Line,
 	(mark: MarkBuilder, props) => {

--- a/packages/client/react/src/marks/Path.ts
+++ b/packages/client/react/src/marks/Path.ts
@@ -8,15 +8,23 @@ import {
 	MarkEncoding,
 	MarkEncodingKey,
 } from '@chart-parts/interfaces'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { MarkBuilder } from '@chart-parts/builder'
 import { useEffect } from 'react'
 
+/**
+ * Path Mark Component Props
+ * @category Mark
+ */
 export interface PathProps extends CommonMarkProps {
 	path?: MarkEncoding<string>
 }
 
+/**
+ * Path Mark Component
+ * @category Mark
+ */
 export const Path = createMarkComponent<PathProps>(
 	MarkType.Path,
 	(mark: MarkBuilder, props) => {

--- a/packages/client/react/src/marks/Rect.ts
+++ b/packages/client/react/src/marks/Rect.ts
@@ -8,15 +8,23 @@ import {
 	MarkEncodingKey,
 	MarkEncoding,
 } from '@chart-parts/interfaces'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { MarkBuilder } from '@chart-parts/builder'
 import { useEffect } from 'react'
 
+/**
+ * Rect Mark Component Props
+ * @category Mark
+ */
 export interface RectProps extends CommonMarkProps {
 	cornerRadius?: MarkEncoding<number>
 }
 
+/**
+ * Rect Mark Component
+ * @category Mark
+ */
 export const Rect = createMarkComponent<RectProps>(
 	MarkType.Rect,
 	(mark: MarkBuilder, props) => {

--- a/packages/client/react/src/marks/Rule.ts
+++ b/packages/client/react/src/marks/Rule.ts
@@ -4,9 +4,17 @@
  */
 
 import { MarkType } from '@chart-parts/interfaces'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 
+/**
+ * Rule Mark Component Props
+ * @category Mark
+ */
 export type RuleProps = CommonMarkProps
 
+/**
+ * Rule Mark Component
+ * @category Mark
+ */
 export const Rule = createMarkComponent<RuleProps>(MarkType.Rule)

--- a/packages/client/react/src/marks/Symbol.ts
+++ b/packages/client/react/src/marks/Symbol.ts
@@ -9,16 +9,24 @@ import {
 	MarkEncodingKey,
 	MarkEncoding,
 } from '@chart-parts/interfaces'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { useEffect } from 'react'
 import { MarkBuilder } from '@chart-parts/builder'
 
+/**
+ * Symbol Mark Component Props
+ * @category Mark
+ */
 export interface SymbolProps extends CommonMarkProps {
 	size?: MarkEncoding<number>
 	shape?: MarkEncoding<SymbolType | string>
 }
 
+/**
+ * Symbol Mark Component
+ * @category Mark
+ */
 export const Symbol = createMarkComponent<SymbolProps>(
 	MarkType.Symbol,
 	(mark: MarkBuilder, props) => {

--- a/packages/client/react/src/marks/SymbolTypes.ts
+++ b/packages/client/react/src/marks/SymbolTypes.ts
@@ -8,15 +8,23 @@ import {
 	MarkEncoding,
 	MarkEncodingKey,
 } from '@chart-parts/interfaces'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { MarkBuilder } from '@chart-parts/builder'
 import { useEffect } from 'react'
 
+/**
+ * SymbolOfType Component Props
+ * @category Mark
+ */
 export interface SymbolOfTypeProps extends CommonMarkProps {
 	size?: MarkEncoding<number>
 }
 
+/**
+ * A factory function for creating a symbol component
+ * @param shape The shape to use
+ */
 function createSymbolMark(shape: SymbolType) {
 	return createMarkComponent<SymbolOfTypeProps>(
 		MarkType.Symbol,
@@ -31,11 +39,50 @@ function createSymbolMark(shape: SymbolType) {
 	)
 }
 
+/**
+ * Circle Symbol Component
+ * @category Mark
+ */
 export const Circle = createSymbolMark(SymbolType.Circle)
+
+/**
+ * Cross Symbol Component
+ * @category Mark
+ */
 export const Cross = createSymbolMark(SymbolType.Cross)
+
+/**
+ * Diamond Symbol Component
+ * @category Mark
+ */
 export const Diamond = createSymbolMark(SymbolType.Diamond)
+
+/**
+ * Square Symbol Component
+ * @category Mark
+ */
 export const Square = createSymbolMark(SymbolType.Square)
+
+/**
+ * Triangle-Down Symbol Component
+ * @category Mark
+ */
 export const TriangleDown = createSymbolMark(SymbolType.TriangleDown)
+
+/**
+ * Triangle-Up Symbol Component
+ * @category Mark
+ */
 export const TriangleUp = createSymbolMark(SymbolType.TriangleUp)
+
+/**
+ * Triangle-Left Symbol Component
+ * @category Mark
+ */
 export const TriangleLeft = createSymbolMark(SymbolType.TriangleLeft)
+
+/**
+ * Triangle-Right Symbol Component
+ * @category Mark
+ */
 export const TriangleRight = createSymbolMark(SymbolType.TriangleRight)

--- a/packages/client/react/src/marks/Text.ts
+++ b/packages/client/react/src/marks/Text.ts
@@ -13,10 +13,14 @@ import {
 	MarkEncodingKey,
 } from '@chart-parts/interfaces'
 import { MarkBuilder } from '@chart-parts/builder'
-import { CommonMarkProps } from '../interfaces'
+import { CommonMarkProps } from '../types'
 import { createMarkComponent } from './BaseMark'
 import { useEffect } from 'react'
 
+/**
+ * Text Mark Component Props
+ * @category Mark
+ */
 export interface TextProps extends CommonMarkProps {
 	align?: MarkEncoding<HorizontalAlignment>
 	angle?: MarkEncoding<number>
@@ -36,6 +40,10 @@ export interface TextProps extends CommonMarkProps {
 	theta?: MarkEncoding<number>
 }
 
+/**
+ * Text Mark Component
+ * @category Mark
+ */
 export const Text = createMarkComponent<TextProps>(
 	MarkType.Text,
 	(mark: MarkBuilder, props) => {

--- a/packages/client/react/src/scales/DomainRangeScale.ts
+++ b/packages/client/react/src/scales/DomainRangeScale.ts
@@ -5,6 +5,10 @@
 import { ScaleCreationContext } from '@chart-parts/interfaces'
 import { createDomainScale, DomainScaleProps } from './DomainScale'
 
+/**
+ * Common props for scales with both a domain and range
+ * @category Scale
+ */
 export interface DomainRangeScaleProps<Domain, Range, RangeBind>
 	extends DomainScaleProps<Domain> {
 	/**
@@ -23,6 +27,13 @@ export interface DomainRangeScaleProps<Domain, Range, RangeBind>
 	reverse?: boolean
 }
 
+/**
+ * Creates a new domain-range scale
+ * @ignore
+ * @param displayName The name of the scale to create
+ * @param createScale The scale creation function
+ * @param propsToCheck The props to check for scale recreation
+ */
 export function createDomainRangeScale<
 	Props extends DomainRangeScaleProps<Domain, Range, RangeBind>,
 	Domain,

--- a/packages/client/react/src/scales/DomainScale.tsx
+++ b/packages/client/react/src/scales/DomainScale.tsx
@@ -6,6 +6,10 @@ import React, { memo, useContext, useEffect, useMemo } from 'react'
 import { ScaleCreationContext } from '@chart-parts/interfaces'
 import { SceneBuilderContext } from '../Context'
 
+/**
+ * Props for a scale with a domain
+ * @category Scale
+ */
 export interface DomainScaleProps<Domain> {
 	/**
 	 * The name of the scale
@@ -25,6 +29,13 @@ export interface DomainScaleProps<Domain> {
 	domain?: string | ((args: ScaleCreationContext) => Domain) | Domain
 }
 
+/**
+ * Creates a new DomainScale
+ * @ignore
+ * @param displayName The name of the scale
+ * @param createScale The scale creation function
+ * @param propsToCheck Props to check for scale recreation
+ */
 export function createDomainScale<
 	Props extends DomainScaleProps<Domain>,
 	Domain

--- a/packages/client/react/src/scales/QuantileScale.ts
+++ b/packages/client/react/src/scales/QuantileScale.ts
@@ -10,16 +10,29 @@ import {
 } from './DomainRangeScale'
 import { QuantitativeValue } from './quantitative/QuantitativeScale'
 
+/**
+ * Quantile Scale Component Props
+ * @category Scale
+ */
 export interface QuantileScaleProps<
 	DomainValue extends QuantitativeValue,
 	RangeValue extends QuantitativeValue
 > extends DomainRangeScaleProps<[DomainValue, DomainValue], RangeValue[], {}> {}
 
+/**
+ * Quantile Scale Component TYpe
+ * @category Scale
+ */
 export type QuantileScaleComponentType<
 	D extends QuantitativeValue = any,
 	R extends QuantitativeValue = any
 > = React.FC<QuantileScaleProps<D, R>>
 
+/**
+ * Quantile Scale Component
+ * @category Scale
+ * @remarks Based on [d3.scaleQuantile](https://github.com/d3/d3-scale#scaleQuantile)
+ */
 export const QuantileScale: QuantileScaleComponentType = createDomainRangeScale(
 	'QuantileScale',
 	({ name, domain, range, reverse }) =>

--- a/packages/client/react/src/scales/QuantizeScale.ts
+++ b/packages/client/react/src/scales/QuantizeScale.ts
@@ -8,6 +8,10 @@ import {
 	DomainRangeScaleProps,
 } from './DomainRangeScale'
 
+/**
+ * Quantize Scale Component Props
+ * @category Scale
+ */
 export interface QuantizeScaleProps<DomainValue, RangeValue>
 	extends DomainRangeScaleProps<[DomainValue, DomainValue], RangeValue[], {}> {
 	/**
@@ -22,10 +26,19 @@ export interface QuantizeScaleProps<DomainValue, RangeValue>
 	zero?: boolean
 }
 
+/**
+ * Quantize Scale Component Type
+ * @category Scale
+ */
 export type QuantizeScaleComponentType<D = any, R = any> = React.FC<
 	QuantizeScaleProps<D, R>
 >
 
+/**
+ * Quantize Scale Component
+ * @category Scale
+ * @remarks Based on [d3.scaleQuantize](https://github.com/d3/d3-scale#scaleQuantize)
+ */
 export const QuantizeScale: QuantizeScaleComponentType = createDomainRangeScale(
 	'QuantizeScale',
 	({ name, domain, range, reverse, nice, zero }) =>

--- a/packages/client/react/src/scales/Scale.tsx
+++ b/packages/client/react/src/scales/Scale.tsx
@@ -6,12 +6,31 @@
 import React, { memo, useContext, useEffect } from 'react'
 import { SceneBuilderContext } from '../Context'
 
+/**
+ * Generic scale props
+ * @category Scale
+ */
 export interface ScaleProps {
+	/**
+	 * The name of the scale
+	 */
 	name: string
+
+	/**
+	 * The table the scale is applied to
+	 */
 	table: string
+
+	/**
+	 * A factory function for creating the scale
+	 */
 	create: (args: any) => any
 }
 
+/**
+ * Generic scale component
+ * @category Scale
+ */
 export const Scale: React.FC<ScaleProps> = memo(({ create }) => {
 	const api = useContext(SceneBuilderContext)
 	useEffect(() => {

--- a/packages/client/react/src/scales/discrete/BandScale.ts
+++ b/packages/client/react/src/scales/discrete/BandScale.ts
@@ -10,6 +10,10 @@ import {
 	DomainRangeScaleProps,
 } from '../DomainRangeScale'
 
+/**
+ * BandScale Component Props
+ * @category Scale
+ */
 export interface BandScaleProps
 	extends DomainRangeScaleProps<string[], [number, number], Dimension> {
 	/**
@@ -43,6 +47,11 @@ export interface BandScaleProps
 	round?: boolean
 }
 
+/**
+ * BandScale React component
+ * @category Scale
+ * @remarks Based on the [d3 bandScale](https://github.com/d3/d3-scale#band-scales)
+ */
 export const BandScale: React.FC<BandScaleProps> = createDomainRangeScale<
 	BandScaleProps,
 	string[],

--- a/packages/client/react/src/scales/discrete/OrdinalScale.ts
+++ b/packages/client/react/src/scales/discrete/OrdinalScale.ts
@@ -6,6 +6,10 @@
 import { ordinal, CategoricalColorScheme } from '@chart-parts/scales'
 import { createDomainScale, DomainScaleProps } from '../DomainScale'
 
+/**
+ * OrdinalScale Component Props
+ * @category Scale
+ */
 export interface OrdinalScaleProps<RangeType>
 	extends DomainScaleProps<string[]> {
 	/**
@@ -19,10 +23,19 @@ export interface OrdinalScaleProps<RangeType>
 	colorScheme?: CategoricalColorScheme
 }
 
+/**
+ * Generic Ordinal Scale Typing
+ * @category Scale
+ */
 export type OrdinalScaleComponentType<RangeType = any> = React.FC<
 	OrdinalScaleProps<RangeType>
 >
 
+/**
+ * Ordinal Scale Component
+ * @category Scale
+ * @remarks Based on [d3 Ordinal Scale](https://github.com/d3/d3-scale#scaleOrdinal)
+ */
 export const OrdinalScale: OrdinalScaleComponentType = createDomainScale(
 	'OrdinalScale',
 	({ name, domain, range, colorScheme }) =>

--- a/packages/client/react/src/scales/discrete/PointScale.ts
+++ b/packages/client/react/src/scales/discrete/PointScale.ts
@@ -10,6 +10,10 @@ import {
 	DomainRangeScaleProps,
 } from '../DomainRangeScale'
 
+/**
+ * PointScale Component props
+ * @category Scale
+ */
 export interface PointScaleProps
 	extends DomainRangeScaleProps<string[], [number, number], Dimension> {
 	/**
@@ -28,6 +32,11 @@ export interface PointScaleProps
 	padding?: number
 }
 
+/**
+ * PointScale Component
+ * @category Scale
+ * @remarks Based on [d3.scalePoint](https://github.com/d3/d3-scale#scalePoint)
+ */
 export const PointScale: React.FC<PointScaleProps> = createDomainRangeScale(
 	'PointScale',
 	({

--- a/packages/client/react/src/scales/quantitative/LinearScale.ts
+++ b/packages/client/react/src/scales/quantitative/LinearScale.ts
@@ -10,6 +10,10 @@ import {
 	createQuantitativeScale,
 } from './QuantitativeScale'
 
+/**
+ * Linear Scale Component
+ * @category Scale
+ */
 export const LinearScale = createQuantitativeScale<
 	QuantitativeScaleProps<QuantitativeValue, number>,
 	QuantitativeValue,

--- a/packages/client/react/src/scales/quantitative/LogScale.ts
+++ b/packages/client/react/src/scales/quantitative/LogScale.ts
@@ -10,11 +10,20 @@ import {
 	QuantitativeValue,
 } from './QuantitativeScale'
 
+/**
+ * Log Scale properties
+ * @category Scale
+ */
 export interface LogScaleProps
 	extends QuantitativeScaleProps<QuantitativeValue, number> {
 	base?: number
 }
 
+/**
+ * LogScale Component
+ * @remark Based on [d3.scaleLog](https://github.com/d3/d3-scale#scaleLog)
+ * @category Scale
+ */
 export const LogScale = createQuantitativeScale<
 	LogScaleProps,
 	QuantitativeValue,

--- a/packages/client/react/src/scales/quantitative/PowScale.ts
+++ b/packages/client/react/src/scales/quantitative/PowScale.ts
@@ -10,11 +10,20 @@ import {
 	QuantitativeValue,
 } from './QuantitativeScale'
 
+/**
+ * PowScale Component Props
+ * @category Scale
+ */
 export interface PowScaleProps
 	extends QuantitativeScaleProps<QuantitativeValue, number> {
 	exponent?: number
 }
 
+/**
+ * PowScale Component
+ * @category Scale
+ * @remarks Based on [d3.scalePow](https://github.com/d3/d3-scale#scalePow)
+ */
 export const PowScale = createQuantitativeScale<
 	PowScaleProps,
 	QuantitativeValue,

--- a/packages/client/react/src/scales/quantitative/QuantitativeScale.ts
+++ b/packages/client/react/src/scales/quantitative/QuantitativeScale.ts
@@ -9,10 +9,28 @@ import {
 } from '../DomainRangeScale'
 import { Dimension } from '@chart-parts/interfaces'
 
+/**
+ * A time-based scale value
+ * @category Scale
+ */
 export type TimeValue = QuantitativeValue | Date
+
+/**
+ * A quantitative value
+ * @category Scale
+ */
 export type QuantitativeValue = number | { valueOf(): number }
+
+/**
+ * A span of quantitative values
+ * @category Scale
+ */
 export type QuantitativeSpan = [QuantitativeValue, QuantitativeValue]
 
+/**
+ * Quantitative Scale Component Props
+ * @category Scale
+ */
 export interface QuantitativeScaleProps<DomainValue, RangeValue>
 	extends DomainRangeScaleProps<
 		[DomainValue, DomainValue],
@@ -49,6 +67,13 @@ export interface QuantitativeScaleProps<DomainValue, RangeValue>
 	round?: boolean
 }
 
+/**
+ * Quantitative scale foctory
+ * @ignore
+ * @param displayName The display name of the scale
+ * @param createScale The scale creation function
+ * @param propsToCheck Props to inspect for scale recreations
+ */
 export function createQuantitativeScale<
 	Props extends QuantitativeScaleProps<DomainValue, RangeValue>,
 	DomainValue extends QuantitativeValue,

--- a/packages/client/react/src/scales/quantitative/SequentialScale.ts
+++ b/packages/client/react/src/scales/quantitative/SequentialScale.ts
@@ -7,12 +7,21 @@ import { sequential } from '@chart-parts/scales'
 import { createDomainScale, DomainScaleProps } from '../DomainScale'
 import { QuantitativeValue, QuantitativeSpan } from './QuantitativeScale'
 
+/**
+ * Sequential Scale Component Props
+ * @category Scale
+ */
 export interface SequantialScaleProps
 	extends DomainScaleProps<QuantitativeSpan> {
 	interpolator: (t: QuantitativeValue) => any
 	clamp?: boolean
 }
 
+/**
+ * Sequential Scale Component
+ * @category Scale
+ * @remark Based on [d3.scaleSequential](https://github.com/d3/d3-scale#sequential-scales)
+ */
 export const SequentialScale = createDomainScale<
 	SequantialScaleProps,
 	QuantitativeSpan

--- a/packages/client/react/src/scales/quantitative/SqrtScale.ts
+++ b/packages/client/react/src/scales/quantitative/SqrtScale.ts
@@ -10,6 +10,11 @@ import {
 	QuantitativeValue,
 } from './QuantitativeScale'
 
+/**
+ * Sqrt Scale Component
+ * @category Scale
+ * @remark Based on [d3.scaleSqrt](https://github.com/d3/d3-scale#scaleSqrt)
+ */
 export const SqrtScale = createQuantitativeScale<
 	QuantitativeScaleProps<QuantitativeValue, number>,
 	QuantitativeValue,

--- a/packages/client/react/src/scales/quantitative/TimeScale.ts
+++ b/packages/client/react/src/scales/quantitative/TimeScale.ts
@@ -10,9 +10,18 @@ import {
 	TimeValue,
 } from './QuantitativeScale'
 
+/**
+ * TimeScale Component Props
+ * @category Scale
+ */
 export interface TimeScaleProps
 	extends QuantitativeScaleProps<TimeValue, number> {}
 
+/**
+ * TimeScale Component
+ * @category Scale
+ * @remark Based on [d3.scaleTime](https://github.com/d3/d3-scale#scaleTime)
+ */
 export const TimeScale = createQuantitativeScale<
 	TimeScaleProps,
 	TimeValue,

--- a/packages/client/react/src/scales/quantitative/UtcScale.ts
+++ b/packages/client/react/src/scales/quantitative/UtcScale.ts
@@ -10,6 +10,11 @@ import {
 	TimeValue,
 } from './QuantitativeScale'
 
+/**
+ * Utc Scale Component
+ * @category Scale
+ * @remark Based on [d3.scaleUtc](https://github.com/d3/d3-scale#scaleUtc)
+ */
 export const UtcScale = createQuantitativeScale<
 	QuantitativeScaleProps<TimeValue, number>,
 	TimeValue,

--- a/packages/client/react/src/types.ts
+++ b/packages/client/react/src/types.ts
@@ -12,6 +12,10 @@ import {
 	Metadata,
 } from '@chart-parts/interfaces'
 
+/**
+ * Commonly available encoding parameters for Mark components
+ * @category Mark
+ */
 export interface CommonMarkEncodings {
 	// Common Mark Value Encodings
 	x?: MarkEncoding<number>
@@ -45,6 +49,10 @@ export interface CommonMarkEncodings {
 	tabIndex?: MarkEncoding<number>
 }
 
+/**
+ * Commonly Available Event Handlers for Mark Components
+ * @category Mark
+ */
 export interface CommonMarkChannels {
 	// Clipboard Events
 	onCopy?: ChannelHandler<React.ClipboardEvent<any>>
@@ -110,6 +118,7 @@ export interface CommonMarkChannels {
 
 /**
  * Common mark-component properties
+ * @category Mark
  */
 export interface CommonMarkProps
 	extends CommonMarkEncodings,
@@ -132,43 +141,4 @@ export interface CommonMarkProps
 
 	// Events
 	eventHandlers?: { [key: string]: ChannelHandler<any> }
-}
-
-export function captureCommonEncodings<T extends CommonMarkProps>(props: T) {
-	const result: { [key: string]: any } = {}
-	const transferProp = (name: string) => {
-		const propVal = (props as any)[name]
-		if (propVal !== undefined) {
-			result[name] = propVal
-		}
-	}
-	;[
-		'x',
-		'x2',
-		'xc',
-		'width',
-		'y',
-		'y2',
-		'yc',
-		'height',
-		'opacity',
-		'fill',
-		'fillOpacity',
-		'stroke',
-		'strokeOpacity',
-		'strokeWidth',
-		'strokeCap',
-		'strokeDash',
-		'strokeDashOffset',
-		'strokeJoin',
-		'strokeMiterLimit',
-		'cursor',
-		'href',
-		'tooltip',
-		'zIndex',
-		'ariaTitle',
-		'ariaDescription',
-		'tabIndex',
-	].map(pv => transferProp(pv))
-	return result
 }

--- a/packages/docs/docsite/package.json
+++ b/packages/docs/docsite/package.json
@@ -58,7 +58,7 @@
     "type-check": "tsc --noEmit",
     "clean:docs": "rimraf static/apidocs",
     "gen:docs": "run-p gen:doc:*",
-    "gen:doc": "typedoc --theme minimal --out static/apidocs/$LIB --tsconfig ../../$LIB/tsconfig.typedoc.json --ignoreCompilerErrors --excludePrivate --hideGenerator",
+    "gen:doc": "typedoc --theme default --out static/apidocs/$LIB --tsconfig ../../$LIB/tsconfig.typedoc.json  --ignoreCompilerErrors --excludePrivate --excludeNotExported --hideGenerator --mode file",
     "gen:doc:builder": "LIB=client/builder yarn gen:doc",
     "gen:doc:interfaces": "LIB=client/interfaces yarn gen:doc",
     "gen:doc:react": "LIB=client/react yarn gen:doc",

--- a/packages/docs/docsite/tsdoc.json
+++ b/packages/docs/docsite/tsdoc.json
@@ -1,0 +1,34 @@
+{
+  "tags": {
+    "allowUnknownTags": true
+  },
+  "plugins": [
+    "plugins/markdown",
+    "/Users/christrevino/Workspace/oss/chart-parts/packages/docs/docsite/node_modules/tsdoc/template/plugins/TSDoc.js"
+  ],
+  "opts": {
+    "template": "/Users/christrevino/Workspace/oss/chart-parts/packages/docs/docsite/node_modules/tsdoc/template",
+    "recurse": "true"
+  },
+  "templates": {
+    "cleverLinks": false,
+    "monospaceLinks": false
+  },
+  "source": {
+    "includePattern": "(\\.d)?\\.ts$"
+  },
+  "markdown": {
+    "parser": "gfm",
+    "hardwrap": true
+  },
+  "tsdoc": {
+    "source": "/Users/christrevino/Workspace/oss/chart-parts/packages/docs/docsite/src/",
+    "destination": "/Users/christrevino/Workspace/oss/chart-parts/packages/docs/docsite/docs",
+    "tutorials": "",
+    "systemName": "docsite",
+    "footer": "",
+    "copyright": "docsite Copyright © 2019 christrevino.",
+    "outputSourceFiles": true,
+    "commentsOnly": true
+  }
+}


### PR DESCRIPTION
* Use file mode so that the APIDoc list view shows the exports instead of the module files in the package
* Categorize exports per package