### PR TITLE
chore: gsap package and lock file updated

### DIFF
--- a/packages/docs/docsite/package.json
+++ b/packages/docs/docsite/package.json
@@ -35,7 +35,7 @@
     "gatsby-remark-prismjs": "^3.3.22",
     "gatsby-source-filesystem": "^2.1.36",
     "gatsby-transformer-remark": "^2.6.33",
-    "gsap": "^2.1.3",
+    "gsap": "^3.0.1",
     "prismjs": "^1.16.0",
     "prop-types": "^15.6.2",
     "react": "^16.9.0",

--- a/packages/docs/docsite/src/components/splash/splash.hooks.ts
+++ b/packages/docs/docsite/src/components/splash/splash.hooks.ts
@@ -5,7 +5,7 @@
 
 import { useEffect, useState, RefObject, useCallback } from 'react'
 import { randomBetween } from '../../util/util'
-import { TimelineMax, Elastic, TweenLite, Sine } from 'gsap'
+import { TimelineMax, TweenLite } from 'gsap'
 
 // get all chart part elements
 function getChartPartsChars() {
@@ -75,7 +75,7 @@ export function useSplashPageMountAnimation(
 							rotation: randomBetween(-360, 60),
 							rotationX: randomBetween(-200, 200),
 							rotationY: randomBetween(-60, 60),
-							ease: Elastic.easeOut.config(1, 0.4),
+							ease: 'elastic.out(1, 0.4)',
 							delay: 0.1,
 						},
 						'PieceTogether+=' + Math.random() * 0.3
@@ -102,7 +102,7 @@ export function useSplashPageMountAnimation(
 								rotationX: randomBetween(-160, 160),
 								rotationY: randomBetween(-160, 160),
 								opacity: 0,
-								ease: Elastic.easeOut.config(1, 0.4),
+								ease: 'elastic.out(1, 0.4)',
 							},
 							'PieceTogether+=' + Math.random() * 0.3
 						)
@@ -114,7 +114,7 @@ export function useSplashPageMountAnimation(
 					0.3,
 					{
 						opacity: 0,
-						easing: Elastic.easeIn,
+						ease: 'elastic.in(1, 0.3)',
 						delay: 0.7,
 					},
 					'Scale+=' + 0.1
@@ -210,7 +210,7 @@ export function usePaneMousehandlers(
 	const mouseEnter = useCallback(() => {
 		if (ref && ref.current && animationComplete) {
 			TweenLite.to(ref.current, 0.5, {
-				ease: Sine.easeOut,
+				ease: 'sine.out',
 				opacity: 1.0,
 			})
 		}
@@ -220,7 +220,7 @@ export function usePaneMousehandlers(
 	const mouseLeave = useCallback(() => {
 		if (ref && ref.current && animationComplete) {
 			TweenLite.to(ref.current, 0.5, {
-				ease: Sine.easeOut,
+				ease: 'sine.out',
 				opacity: 0.8,
 			})
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9402,10 +9402,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gsap@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/gsap/-/gsap-2.1.3.tgz#c63ee3a50f0b7dc3b46ed0845bb0f09049feb944"
-  integrity sha512-8RFASCqi2FOCBuv7X4o7M6bLdy+1hbR0azg+MG7zz+EVsI+OmJblYsTk0GEepQd2Jg/ItMPiVTibF7r3EVxjZQ==
+gsap@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/gsap/-/gsap-3.0.1.tgz#946b49e860487bd23e6c884b95152d556a5f86f1"
+  integrity sha512-9nzEBF7Ss9Ogyw6oEOXZxxVYH8WNRA/nHmIp3DrPOTKmlLxX9MN2ovSoH9TApA+rucBgp9veCedujp5oSQRvZw==
 
 gud@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
updated gsap to latest version 3.0.1. There is no upgrade available for types (@types/gsap).  The animation in the splash.hook.ts is updated to reflect dep version change. 