### PR TITLE
build: Update deploy to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,19 +9,23 @@ jobs:
   build-deploy:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@master
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
 
-      - run: yarn install
-      - run: yarn build
-      - run: yarn lerna run build --stream --scope @chart-parts/docsite
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
 
-      - name: deploy
-        uses: peaceiris/actions-gh-pages@v2.5.0
-        env:
-          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: ./packages/docs/docsite/public
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - run: yarn install
+    - run: yarn build
+    - run: yarn lerna run build --stream --scope @chart-parts/docsite
+
+    - name: deploy
+      uses: JamesIves/github-pages-deploy-action@3.5.9
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: packages/docs/docsite/public


### PR DESCRIPTION
Changes out the action so you can use the built-in GITHUB_TOKEN secret and remove user PAT